### PR TITLE
Hotfix: CodingKeys is not exported in the NPM module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export { Codable, CodableType } from './codable';
+export * from './codable';

--- a/test/codable.spec.ts
+++ b/test/codable.spec.ts
@@ -1,4 +1,4 @@
-import { Codable, CodableType, CodingKeys } from '../src/codable'
+import { Codable, CodableType, CodingKeys } from '../src'
 
 describe('Codable test suite', () => {
   const jsonString = `{


### PR DESCRIPTION
There's currently a bug where `index.ts` does not export `CodingKeys` from `codable.ts`. This means that this code won't compile:

```
import { Codable, CodableType, CodingKeys } from 'codable'
```

Instead, you have to use this:

```
import { Codable, CodableType, CodingKeys } from 'codable/dist/src/codable'
```

To fix this issue, this PR uses the wildcard `*` in `index.ts` to future-proof this fix. Now anything exported in `codable.ts` will also be exported by `index.ts`.

Additionally, I modified the test spec to import from the index of the `src` folder, rather than directly from `codable.ts`, to ensure that the tests will always match the behavior that users experience when importing the `codable` module.